### PR TITLE
Missing break in switch-case.

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -248,7 +248,7 @@ bool getResultSet( Local<Value> 			&Result
 		switch( col_types[count] ) {
 		    case A_INVALID_TYPE:
 			curr_row->Set( String::NewSymbol( colNames[i] ), Null() );
-		    
+		        break;
 		    case A_VAL32:
 		    case A_VAL16:
 		    case A_UVAL16:


### PR DESCRIPTION
Fixed issue resulting in segfault and sometimes incorrect result set mapping.

To reproduce before you merge...

_Incorrect result map:_

```
var sqlanywhere = require('sqlanywhere');
var conn = sqlanywhere.createConnection();
conn.connect({host: 'xxxx', uid: 'xxxx', pwd: 'xxxx'}, function() {
    console.log(conn.exec('select 1 as a, 2 as b, null as c, 1 as d'));
    conn.disconnect();
});
// Prints [ { a: 1, b: 2, c: 1, d: null } ].....Note the null is associated with "d" now.
```

_Segfault_

```
var sqlanywhere = require('sqlanywhere');
var conn = sqlanywhere.createConnection();
conn.connect({host: 'xxxx', uid: 'xxxx', pwd: 'xxxx'}, function() {
    console.log(conn.exec('select 1, null, null'));
    conn.disconnect();
});
```

I tried running these tests against SQL Anywhere 10.0.1.3960 and 12.0.1.3873.
